### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DotSnap helps you to finally see your beautiful desktop wallpaper again. Quickly
 Read more about it & See how it works:
 http://bit.ly/1qeoMZr
 
-##Installation
+## Installation
 
 - Open a terminal prompt and execute:
 
@@ -19,7 +19,7 @@ http://bit.ly/1qeoMZr
 - After git finishes pulling all of the project's dependencies, open the provided Xcode project and click Run.
 - Profit
 
-##Known Issues
+## Known Issues
 
 - 1. For users using CloudApp: If CloudApp auto-upload is active, CloudApp sometimes uploads broken screenshots because DotSnap already moved the screenshot into a different folder. Since CloudApp became very slow since the past few months, this issue occurs more often than expected.
 
@@ -27,12 +27,12 @@ http://bit.ly/1qeoMZr
 - 2. Since Dropbox introduced an option to move screenshots automatically to your Dropbox folder, DotSnap runs into some issues here as well.
  
 
-##How DotSnap works
+## How DotSnap works
 DotSnap works in the background and is compatible with your default Mac screenshot shortcut. It essentially just moves your files to the folder you set inside DotSnap as well as renames the file according to your setting in DotSnap. If you haven't activated the TimeStamp option, files with the same name will get a unique number added to the end.
 
-##Contact
+## Contact
 If you have any questions, comments, or want to contribute, you can reach us on Twitter [@CodaFi_](https://twitter.com/CodaFi_) and [@schneidertobias](https://twitter.com/schneidertobias)
 
-##Download latest Build here (if you just want to install it)
+## Download latest Build here (if you just want to install it)
 https://github.com/DotMail/DotSnap/releases/tag/1.0
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
